### PR TITLE
feat: add allow-plugins in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,11 @@
         "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "pestphp/pest-plugin": true
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
I guess it is better for DX to add the allowed plugins directly in composer.json

Will fix
https://github.com/Chris53897/health-check-results/actions/runs/6717074043