### PR TITLE
update array type of CheckResult::meta

### DIFF
--- a/src/CheckResult.php
+++ b/src/CheckResult.php
@@ -15,7 +15,7 @@ class CheckResult
      * @param string $notificationMessage
      * @param string $shortSummary
      * @param string $status
-     * @param array<int, mixed> $meta
+     * @param array<int|string, mixed> $meta
      *
      * @return self
      */
@@ -35,7 +35,7 @@ class CheckResult
      * @param string $notificationMessage
      * @param string $shortSummary
      * @param string $status
-     * @param array<int, mixed> $meta
+     * @param array<int|string, mixed, mixed> $meta
      */
     public function __construct(
         public string $name,


### PR DESCRIPTION
Your [own docs](https://ohdear.app/docs/features/application-health-monitoring#any-php-application) give this example: 

```php
$checkResult = new CheckResult(
    name: 'UsedDiskSpace',
    label: 'Used disk space',
    notificationMessage: 'Your disk is almost full (91%)',
    shortSummary: '91%',
    status: CheckResult::STATUS_FAILED,
    meta: ['used_disk_space_percentage' => 91]
);
```

But `['used_disk_space_percentage' => 91]` isn't `arra<int, string>` so PHPStan isn't happy about this.